### PR TITLE
Add `--verbose` flag for optional logging

### DIFF
--- a/lib/httpServer.js
+++ b/lib/httpServer.js
@@ -8,6 +8,8 @@ const cors = require('@koa/cors')
 const route = require('koa-route')
 const static = require('koa-static')
 
+const opts = require('minimist')(process.argv.slice(2));
+
 const log = () => async (context, next) => {
   const requestBody = util.inspect(context.request.body)
   console.log(`<- ${context.url} ${requestBody}`)
@@ -50,7 +52,9 @@ const facts = async context => {
 const app = new Koa()
 app.use(cors())
 app.use(body())
-app.use(log())
+if (opts.verbose) {
+  app.use(log())
+}
 app.use(client())
 app.use(route.post('/assert', assert))
 app.use(route.post('/select', select))

--- a/lib/socketServer.js
+++ b/lib/socketServer.js
@@ -2,11 +2,15 @@ const socket = require('koa-socket')
 const io = new socket()
 const util = require('util')
 
+const opts = require('minimist')(process.argv.slice(2));
+
 const client = (app) => async (context, next) => {
   context.state = context.state || { client: null }
   context.state.client = context.state.client ||
     io.state.room.connect(context.data.id)
-  console.log(util.inspect(context.state.client))
+    if (opts.verbose) {
+      console.log(util.inspect(context.state.client))
+    }
   await next()
 }
 
@@ -17,7 +21,9 @@ const log = () => async (context, next) => {
 }
 
 io.use(client())
-io.use(log())
+if (opts.verbose) {
+  io.use(log())
+}
 
 io.on('id', async context => {
   context.socket.emit('id', context.state.client.id)

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "koa-route": "3",
     "koa-socket": "^4.4.0",
     "koa-static": "^4.0.2",
+    "minimist": "^1.2.0",
     "roomdb": "alexwarth/roomdb#modularify"
   }
 }


### PR DESCRIPTION
Logging has substantial performance costs (particularly as the database grows), so it shouldn't be enabled by default. This adds a `--verbose` flag to enable logging for development/debugging purposes.

Usage: `npm start -- --verbose`