### PR TITLE
fix http server

### DIFF
--- a/lib/httpServer.js
+++ b/lib/httpServer.js
@@ -18,33 +18,31 @@ const log = () => async (context, next) => {
   console.log(`-> ${context.url} ${responseBody}`)
 }
 
-const client = () => async (context, next) => {
-  context.state.client = await context.room.connect()
-  await next()
-  context.state.client.disconnect()
-}
-
 const assert = async context => {
   const {fact} = context.request.body
-  await context.state.client.assert(fact)
+  await context.client.immediatelyAssert(fact)
+  context.status = 200
 }
 
 const retract = async context => {
   const {fact} = context.request.body
-  await context.state.client.retract(fact)
+  await context.client.immediatelyRetract(fact)
+  context.status = 200
 }
 
 const select = async context => {
   const {facts} = context.request.body
-  await context.state.client
+  context.body = (context.body === undefined) ? {} : context.body
+  context.body.solutions = []
+  await context.client
     .select(facts)
-    .doAll(solutions => {
-      context.body = { solutions }
+    .do(solution => {
+      context.body.solutions.push(solution)
     })
 }
 
 const facts = async context => {
-  ctx.body = context.room.client.facts
+  ctx.body = context.client.facts
 }
 
 const app = new Koa()
@@ -53,14 +51,13 @@ app.use(body())
 if (opts.verbose) {
   app.use(log())
 }
-app.use(client())
 app.use(route.post('/assert', assert))
 app.use(route.post('/select', select))
 app.use(route.post('/retract', retract))
 app.use(route.post('/facts', facts))
 app.use(static('examples'))
 
-module.exports = room => {
-  app.context.room = room
+module.exports = client => {
+  app.context.client = client
   return app
 }

--- a/readme.md
+++ b/readme.md
@@ -25,10 +25,10 @@ After deploying the default branch, the post-receive hook checks it out and rest
 ## example http
 
     $ curl -d '{"fact": "#curl is an app at (20, 30)"}' -H "Content-Type: application/json" localhost:3000/assert
-    {"id":1}
+    OK
 
     $ curl -d '{"facts": ["$what is an app at ($x, $y)"]}' -H "Content-Type: application/json" localhost:3000/select
-    {"solutions":[{"what":{"name":"curl"},"x":20,"y":30}]}
+    {"solutions":[{"what":{"id":"curl"},"x":20,"y":30}]}
 
 ## example websocket
 


### PR DESCRIPTION
The http server wasn't working for me since [fa1da8](https://github.com/jedahan/room-server/commit/fa1da899d1fcab6742ebca77e0ee54cd0f1114e1) switched to a different branch of the `roomdb` dependency.

With this branch, the `curl` demo works again, and the `room-client` demo works with a small modification (for handling a change in the keys defined on string terms)

I was missing a lot of context about changes to roomdb so I just made pragmatic changes here to get things working. Would appreciate any feedback on this diff to deepen my understanding of the direction of the codebase. Also of course feel free to just decline this PR if these fixes are already being handled elsewhere.